### PR TITLE
Implemented more operations for rug::Complex and rug::Rational

### DIFF
--- a/src/num/rugcomplex.rs
+++ b/src/num/rugcomplex.rs
@@ -120,6 +120,22 @@ impl Num for Complex {
 
 		Ok(Answer::Single(a))
 	}
+	
+	fn ceil(&self, ctx: &Context<Self>) -> Calculation<Self> {
+		let r = Complex::real(self).ceil_ref();
+		let i = Complex::real(self).ceil_ref();
+		let a = Complex::with_val(ctx.cfg.precision, (r, i));
+		
+		Ok(Answer::Single(a))
+	}
+	
+	fn round(&self, ctx: &Context<Self>) -> Calculation<Self> {
+		let r = Complex::real(self).round_ref();
+		let i = Complex::real(self).round_ref();
+		let a = Complex::with_val(ctx.cfg.precision, (r, i));
+		
+		Ok(Answer::Single(a))
+	}
 
 	fn log(&self, other: &Self, ctx: &Context<Self>) -> Calculation<Self> {
 		let n = Complex::with_val(ctx.cfg.precision, Complex::log10_ref(self));

--- a/src/num/rugcomplex.rs
+++ b/src/num/rugcomplex.rs
@@ -123,7 +123,7 @@ impl Num for Complex {
 	
 	fn ceil(&self, ctx: &Context<Self>) -> Calculation<Self> {
 		let r = Complex::real(self).ceil_ref();
-		let i = Complex::real(self).ceil_ref();
+		let i = Complex::imag(self).ceil_ref();
 		let a = Complex::with_val(ctx.cfg.precision, (r, i));
 		
 		Ok(Answer::Single(a))
@@ -131,7 +131,7 @@ impl Num for Complex {
 	
 	fn round(&self, ctx: &Context<Self>) -> Calculation<Self> {
 		let r = Complex::real(self).round_ref();
-		let i = Complex::real(self).round_ref();
+		let i = Complex::imag(self).round_ref();
 		let a = Complex::with_val(ctx.cfg.precision, (r, i));
 		
 		Ok(Answer::Single(a))

--- a/src/num/rugrat.rs
+++ b/src/num/rugrat.rs
@@ -59,4 +59,28 @@ impl Num for Rational {
 
 		Ok(Answer::Single(r))
 	}
+	
+	fn abs(&self, _ctx: &Context<Self>) -> Calculation<Self> {
+		let r = Rational::from(self.abs_ref());
+		
+		Ok(Answer::Single(r))
+	}
+	
+	fn floor(&self, _ctx: &Context<Self>) -> Calculation<Self> {
+		let r = Rational::from(self.floor_ref());
+		
+		Ok(Answer::Single(r))
+	}
+	
+	fn ceil(&self, _ctx: &Context<Self>) -> Calculation<Self> {
+		let r = Rational::from(self.ceil_ref());
+		
+		Ok(Answer::Single(r))
+	}
+	
+	fn round(&self, _ctx: &Context<Self>) -> Calculation<Self> {
+		let r = Rational::from(self.round_ref());
+		
+		Ok(Answer::Single(r))
+	}
 }


### PR DESCRIPTION
I've implemented the `ceil` and `round` methods for rug::Complex, the `nrt` method still needs to be worked out.

I also implemented `abs`, `floor`, `ceil` and `round` for rug::Rational, which i think are the last of the `Num` methods that can be implemented for that type.